### PR TITLE
Render debugging block only if available

### DIFF
--- a/view/frontend/templates/data-layer.phtml
+++ b/view/frontend/templates/data-layer.phtml
@@ -19,4 +19,6 @@ $dataLayerEventsJsonChunks = $dataLayerViewModel->getDataLayerEventsAsJsonChunks
     window.dataLayer.push(<?= /* @noEscape */ $dataLayerEventsJsonChunk ?>);
     <?php endforeach; ?>
 </script>
-<?= $block->getChildBlock('debugging')->setData(['data_layer_view_model' => $dataLayerViewModel])->toHtml() ?>
+<?php if($config->isDebug()): ?>
+    <?= $block->getChildBlock('debugging')->setData(['data_layer_view_model' => $dataLayerViewModel])->toHtml() ?>
+<?php endif; ?>


### PR DESCRIPTION
Fix the following error when debug is not enabled (setting `googletagmanager2/settings/debug`)
```
Error: Call to a member function setData() on bool in /app/vendor/yireo/magento2-googletagmanager2/view/frontend/templates/data-layer.phtml:22
```
Block "debugging" created here https://github.com/yireo/Yireo_GoogleTagManager2/blob/master/view/frontend/layout/default.xml#L71-L76 does not exist when debug is not enabled hence `$block->getChildBlock('debugging')` returns `false` instead of a block object